### PR TITLE
iOS video autoplay Issue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -114,6 +114,7 @@ const enter_fullscreen = {
   type: jsPsychFullScreen,
   fullscreen_mode: true,
   message: `<div><h1>The experiment will switch to full screen mode. <br> Click the button to continue. </h1></div>`,
+  delay_after: 0,
 };
 
 const extend = (fn, code) =>


### PR DESCRIPTION
I did some tests enabling/disabling the `timeline.push(enter_fullscreen);` and it worked when I commented on it.

So I was checking what in the `enter_fullscreen` could be causing the issue. I just noticed that the fullscreen event was happening at the same time that the video was trying to play because of the default delay after. So I changed the `delay_after` to 0 to enter full-screen mode before the video tries to play. It worked on Chrome and Safari for iOS (iPad and iPhone).

> Not sure if there is any other issue, saw that there is a second video on it that is not playing but couldn't find it. When does it need to be played?