### PR TITLE
FIX: Continue button renders text on iOS

### DIFF
--- a/src/css/game_v4.css
+++ b/src/css/game_v4.css
@@ -401,6 +401,8 @@ p  {
 	background: rgba(255, 255, 255, 0);
 	border-width: 2px;
 	border-color: rgba(0, 0, 0, 1);
+	color: rgb(0, 0, 0);
+
 	/* display: inline-block;
 	padding: 1vh 2vh;
 	margin: 1vh;

--- a/src/index.js
+++ b/src/index.js
@@ -214,7 +214,7 @@ timeline.push(...videoTrials.end);
 const exit_fullscreen = {
   type: jsPsychFullScreen,
   fullscreen_mode: false,
-  delay_after: 0,
+  delay_after: 450,
 };
 
 timeline.push(exit_fullscreen);


### PR DESCRIPTION
- Added black color property to make button render text correctly
- Increased delay for full screen to maximum amount while still allowing autoplay to decrease the jarring effect.
![Continue_button](https://user-images.githubusercontent.com/80180474/226063543-048c2dd3-1dc4-457d-a444-06e55f3abe62.PNG)
